### PR TITLE
Solving 500 errors when using bookmarklet or exports

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -28,5 +28,5 @@ location {LOCATION} {
 }
 
 location @wallbag2 {
-  rewrite ^ {PATH}/app.php$is_args$args;
+  rewrite ^ {PATH}/app.php?is_args$args;
 }


### PR DESCRIPTION
This fixes the 500 errors with nginx that currently happen when trying to use the bookmarklet or the exports buttons.