### PR TITLE
Update to 2.2.1 + change source server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Wallabag v2 for Yunohost
 
 **This is a work-in-progress Wallabag v2 package for YunoHost. It's currently looking for new maintainer(s), so feel free to give a shout if you're interested in!**
 
-**Shipped version:** 2.1.4
+**Shipped version:** 2.2.1
 
 [Wallabag](https://www.wallabag.org/) is a self hostable application allowing
 you to not miss any content anymore. Click, save, read it when you can. It

--- a/conf/parameters.yml
+++ b/conf/parameters.yml
@@ -8,7 +8,8 @@ parameters:
     database_path: null
     database_table_prefix: null
     database_socket: null
-
+    database_charset: utf8mb4
+    
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
     mailer_user:       null

--- a/conf/parameters.yml
+++ b/conf/parameters.yml
@@ -37,6 +37,7 @@ parameters:
     rabbitmq_port: 5672
     rabbitmq_user: guest
     rabbitmq_password: guest
+    rabbitmq_prefetch_count: 10
 
     # Redis processing
     redis_scheme: tcp

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     },
     "url": "https://www.wallabag.org",
     "license": "MIT",
-    "version": "2.1.4",
+    "version": "2.2.1",
     "maintainer": {
         "name": "jerome",
         "email": "jerome@yunohost.org"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ VERSION="2.1.4"
 DEPS_PKG_NAME="wallabag-deps"
 
 # Full Wallabag sources tarball URL
-WALLABAG_SOURCE_URL="https://framabag.org/wallabag-release-${VERSION}.tar.gz"
+WALLABAG_SOURCE_URL="https://static.wallabag.org/releases/wallabag-release-${VERSION}.tar.gz"
 
 # Full Wallabag sources tarball checksum
 WALLABAG_SOURCE_SHA256="eb64205a4d7c161527edd08bed22e8dd9799fe8a4130c5964c18cba3a94c9768"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 #
 
 # Wallabag version
-VERSION="2.1.4"
+VERSION="2.2.1"
 
 # Package name for Wallabag dependencies
 DEPS_PKG_NAME="wallabag-deps"
@@ -12,7 +12,7 @@ DEPS_PKG_NAME="wallabag-deps"
 WALLABAG_SOURCE_URL="https://static.wallabag.org/releases/wallabag-release-${VERSION}.tar.gz"
 
 # Full Wallabag sources tarball checksum
-WALLABAG_SOURCE_SHA256="eb64205a4d7c161527edd08bed22e8dd9799fe8a4130c5964c18cba3a94c9768"
+WALLABAG_SOURCE_SHA256="0f60cbab3c89be14a0ae9ce5dbb924458f6527b707847b27097fe91bdd74e14e"
 
 # App package root directory should be the parent folder
 PKGDIR=$(cd ../; pwd)


### PR DESCRIPTION
Update wallabag version to 2.2.1.

----

I changed the source server to Wallabag's server (instead of Framabag).
It is more up to date than Framabag server (right now only 2.1.6 is available), so I don't see any reason to prefer Framabag's server.
Maybe @jeromelebleu you have an explanation ?