### PR TITLE
Update to upstream version 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a work-in-progress Wallabag v2 package for YunoHost.
 
 **NB: Since @jeromelebleu is no longer maintaining this package, I (@lapineige) take over this repository. But I have limited time and experience, so feel free to help !**
 
-**Shipped version:** 2.1.4
+**Shipped version:** 2.2.2
 
 [Wallabag](https://www.wallabag.org/) is a self hostable Read-It-Later application allowing
 you to not miss any content anymore. Click, save, read it when you can.
@@ -24,8 +24,11 @@ this package:
 
 ## TODO
 
- * Improve the LDAP integration, see [#1](https://github.com/YunoHost-Apps/wallabag2_ynh/issues/1)
- * Write the `backup` / `restore` scripts (meanfile please make your own backup, e.g. with the export tool)
+ * Improve the LDAP integration, see [#1](https://github.com/YunoHost-Apps/wallabag2_ynh/issues/1). At the moment you have to apply a workaround to connect via OAuth (iOS, Chrome/Firefox plugin, etc.) by changing your user password:
+   * via the user interface and the recovery e-mail
+   * via CLI on the server: `cd /var/www/wallabag2 ;  sudo -u www-data ./bin/console --env=prod fos:user:change-password`
+ * Write the `backup` / `restore` scripts (meanwhile please make your own backup, e.g. with the export tool)
+ * Refactor the application to apply for replacing wallabag v1 official application!
 
 ## Upgrade from v1
 

--- a/check_process
+++ b/check_process
@@ -1,0 +1,34 @@
+;; Complete test
+	auto_remove=1
+	; Manifest
+		domain="domain.tld"	(DOMAIN)
+		path="/path"	(PATH)
+		admin="john"	(USER)
+	; Checks
+		pkg_linter=1
+		setup_sub_dir=1
+		setup_root=1
+		setup_nourl=0
+		setup_private=0
+		setup_public=0
+		upgrade=1
+		backup_restore=0
+		multi_instance=0
+		wrong_user=1
+		wrong_path=1
+		incorrect_path=1
+		corrupt_source=0
+    fail_download_source=0
+		port_already_use=0
+    final_path_already_use=0
+;;; Levels
+	Level 1=auto
+	Level 2=auto
+	Level 3=auto
+	Level 4=0
+  Level 5=auto
+	Level 6=auto
+	Level 7=auto
+	Level 8=0
+	Level 9=0
+  Level 10=0

--- a/conf/nginx_root.conf
+++ b/conf/nginx_root.conf
@@ -5,9 +5,9 @@ location {LOCATION} {
     rewrite ^ https://$server_name$request_uri? permanent;
   }
 
-  try_files $uri @wallbag2;
+  try_files $uri @wallabag2;
 
-  location ~ ^{PATH}/app\.php(?:$|/) {
+  location ~ ^{PATH}/app\.php(/|$) {
     include fastcgi_params;
     fastcgi_split_path_info ^(.+\.php)(/.*)$;
     fastcgi_param SCRIPT_FILENAME $request_filename;
@@ -27,6 +27,6 @@ location {LOCATION} {
   include conf.d/yunohost_panel.conf.inc;
 }
 
-location @wallbag2 {
-  rewrite ^ {PATH}/app.php$is_args$args;
+location @wallabag2 {
+  rewrite ^ {PATH}/app.php/$is_args$args;
 }

--- a/conf/nginx_sub_dir.conf
+++ b/conf/nginx_sub_dir.conf
@@ -1,0 +1,37 @@
+location {LOCATION}/ {
+  alias {DESTDIR}/web/;
+
+  if ($scheme = http) {
+    rewrite ^ https://$server_name$request_uri? permanent;
+  }
+
+  try_files $uri @wallabag2;
+
+  location ~ ^{PATH}/app\.php(/|$) {
+    include fastcgi_params;
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_param SCRIPT_FILENAME $request_filename;
+    fastcgi_param PATH_INFO       $fastcgi_path_info;
+    fastcgi_param REMOTE_USER     $remote_user;
+    fastcgi_pass unix:/var/run/php5-fpm-{POOLNAME}.sock;
+    fastcgi_intercept_errors on;
+  }
+
+  # return 404 for all other php files not matching the front controller
+  # this prevents access to other php files you don't want to be accessible.
+  location ~ \.php$ {
+    return 404;
+  }
+
+  # Include SSOWAT user panel.
+  include conf.d/yunohost_panel.conf.inc;
+}
+
+location @wallabag2 {
+  rewrite ^ {PATH}/app.php/$is_args$args;
+}
+
+location {LOCATION} {
+  return 301 {LOCATION}/;
+}
+

--- a/conf/parameters.yml
+++ b/conf/parameters.yml
@@ -8,6 +8,7 @@ parameters:
     database_path: null
     database_table_prefix: null
     database_socket: null
+    database_charset: utf8mb4
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
@@ -36,9 +37,14 @@ parameters:
     rabbitmq_port: 5672
     rabbitmq_user: guest
     rabbitmq_password: guest
+    rabbitmq_prefetch_count: 10
 
     # Redis processing
     redis_scheme: tcp
     redis_host: localhost
     redis_port: 6379
     redis_path: null
+    redis_password: null
+ 
+    # sites credentials
+    sites_credentials: {}

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     },
     "url": "https://www.wallabag.org",
     "license": "MIT",
-    "version": "2.1.4",
+    "version": "2.2.2",
     "maintainer": {
         "name": "jerome",
         "email": "jerome@yunohost.org"

--- a/scripts/install
+++ b/scripts/install
@@ -3,16 +3,16 @@
 # Exit on command errors and treat unset variables as an error
 set -eu
 
+# Load common variables and helpers
+source ./_common.sh
+
 # Retrieve app id
 app=$YNH_APP_INSTANCE_NAME
 
 # Retrieve arguments
-domain=$1
-path=${2%/}
-admin=$3
-
-# Load common variables and helpers
-source ./_common.sh
+domain=$YNH_APP_ARG_DOMAIN
+path=$(ynh_normalize_url_path $YNH_APP_ARG_PATH)
+admin=$YNH_APP_ARG_ADMIN
 
 # Set app specific variables
 dbname=$app
@@ -80,12 +80,16 @@ done
 exec_console www-data "$DESTDIR" fos:user:promote --super "$admin"
 
 # Copy and set nginx configuration
-nginx_conf="/etc/nginx/conf.d/${domain}.d/${app}.conf"
-sed -i "s@{LOCATION}@${path:-/}@g" $PKGDIR/conf/nginx.conf
-sed -i "s@{PATH}@${path}@g"        $PKGDIR/conf/nginx.conf
-sed -i "s@{DESTDIR}@${DESTDIR}@g"  $PKGDIR/conf/nginx.conf
-sed -i "s@{POOLNAME}@${app}@g"     $PKGDIR/conf/nginx.conf
-sudo cp $PKGDIR/conf/nginx.conf "$nginx_conf"
+if [[ "$path" == "/" ]] ; then
+  nginx_conf=$PKGDIR/conf/nginx_root.conf
+else
+  nginx_conf=$PKGDIR/conf/nginx_sub_dir.conf
+fi
+sed -i "s@{LOCATION}@${path:-/}@g" "$nginx_conf"
+sed -i "s@{PATH}@${path}@g"        "$nginx_conf"
+sed -i "s@{DESTDIR}@${DESTDIR}@g"  "$nginx_conf"
+sed -i "s@{POOLNAME}@${app}@g"     "$nginx_conf"
+sudo cp "$nginx_conf" "/etc/nginx/conf.d/${domain}.d/${app}.conf"
 
 # Copy and set php-fpm configuration
 phpfpm_conf="/etc/php5/fpm/pool.d/${app}.conf"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -13,8 +13,7 @@ dbuser=$app
 
 # Retrieve arguments
 domain=$(ynh_app_setting_get "$app" domain)
-path=$(ynh_app_setting_get "$app" path)
-path=${path%/}
+path=$(ynh_normalize_url_path $(ynh_app_setting_get "$app" path))
 dbpass=$(ynh_app_setting_get "$app" mysqlpwd)
 deskey=$(ynh_app_setting_get "$app" deskey)
 
@@ -50,12 +49,16 @@ exec_console www-data "$DESTDIR" doctrine:migrations:migrate
 exec_console www-data "$DESTDIR" cache:clear
 
 # Copy and set nginx configuration
-nginx_conf="/etc/nginx/conf.d/${domain}.d/${app}.conf"
-sed -i "s@{LOCATION}@${path:-/}@g" ../conf/nginx.conf
-sed -i "s@{PATH}@${path}@g"        ../conf/nginx.conf
-sed -i "s@{DESTDIR}@${DESTDIR}@g"  ../conf/nginx.conf
-sed -i "s@{POOLNAME}@${app}@g"     ../conf/nginx.conf
-sudo cp ../conf/nginx.conf "$nginx_conf"
+if [[ "$path" == "/" ]] ; then
+  nginx_conf=$PKGDIR/conf/nginx_root.conf
+else
+  nginx_conf=$PKGDIR/conf/nginx_sub_dir.conf
+fi
+sed -i "s@{LOCATION}@${path:-/}@g" "$nginx_conf"
+sed -i "s@{PATH}@${path}@g"        "$nginx_conf"
+sed -i "s@{DESTDIR}@${DESTDIR}@g"  "$nginx_conf"
+sed -i "s@{POOLNAME}@${app}@g"     "$nginx_conf"
+sudo cp "$nginx_conf" "/etc/nginx/conf.d/${domain}.d/${app}.conf"
 
 # Copy and set php-fpm configuration
 phpfpm_conf="/etc/php5/fpm/pool.d/${app}.conf"


### PR DESCRIPTION
This PR replaces PR [#20](https://github.com/YunoHost-Apps/wallabag2_ynh/pull/20): it changes the source server as well.

Since when installing on a subdirectory, the domain/path (without trailing /) was failing, I didn't find any other way to fix than separating two cases for nginx configuration (see `nginx_root.conf` and `nginx_sub_dir.conf`).

It also fixes the known problem with the bookmarklet/Android  application.

@lapineige as you're the new maintainer, it's up to you now ;-)

As a side note, I highly recommend to put some effort into this package to replace wallabag v1 official package, as it is now becoming really obsolete (see my additions to the `README`).
