### PR TITLE
Fix 20-app.ini in restore

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -22,7 +22,7 @@ source /usr/share/yunohost/helpers
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get $app domain)
-final_path="/var/www/${app}"
+final_path=$(ynh_app_setting_get $app final_path)
 db_name=$(ynh_app_setting_get $app db_name)
 
 #=================================================
@@ -32,24 +32,24 @@ db_name=$(ynh_app_setting_get $app db_name)
 #=================================================
 
 CHECK_SIZE "$final_path"
-ynh_backup "$final_path" "sources"
+ynh_backup "$final_path"
 
 #=================================================
 # BACKUP NGINX CONFIGURATION
 #=================================================
 
-ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf" "nginx.conf"
+ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
 # BACKUP PHP-FPM CONFIGURATION
 #=================================================
 
-ynh_backup "/etc/php5/fpm/pool.d/$app.conf" "php-fpm.conf"
+ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
+ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP MYSQL DB
 #=================================================
 
-ynh_mysql_dump_db "$db_name" > dump.sql
-CHECK_SIZE "dump.sql"
-ynh_backup "dump.sql" "db.sql"
+ynh_mysql_dump_db "$db_name" > db.sql
+CHECK_SIZE "db.sql"

--- a/scripts/restore
+++ b/scripts/restore
@@ -31,7 +31,7 @@ db_name=$(ynh_app_setting_get $app db_name)
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
 
-yunohost app checkurl "${domain}${path_url}" -a "$app" \
+ynh_webpath_available $domain $path_url \
 	|| ynh_die "Path not available: ${domain}${path_url}"
 test ! -d $final_path \
 	|| ynh_die "There is already a directory: $final_path "

--- a/scripts/restore
+++ b/scripts/restore
@@ -31,8 +31,10 @@ db_name=$(ynh_app_setting_get $app db_name)
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
 
-CHECK_DOMAINPATH	# Check domain and path availability
-CHECK_FINALPATH # Check if destination directory is not already in use
+yunohost app checkurl "${domain}${path_url}" -a "$app" \
+	|| ynh_die "Path not available: ${domain}${path_url}"
+test ! -d $final_path \
+	|| ynh_die "There is already a directory: $final_path "
 
 #=================================================
 # INSTALL DEPENDENCIES
@@ -46,13 +48,13 @@ ynh_install_app_dependencies "$PKG_DEPENDENCIES"
 # RESTORE NGINX CONFIGURATION
 #=================================================
 
-cp -a ./nginx.conf /etc/nginx/conf.d/$domain.d/$app.conf
+ynh_restore_file "/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
 # RESTORE APP MAIN DIR
 #=================================================
 
-cp -a ./sources/. $final_path
+ynh_restore_file "$final_path"
 
 #=================================================
 # RESTORE MYSQL DB
@@ -78,7 +80,8 @@ chown -R $app: $final_path
 # RESTORE PHP-FPM CONFIGURATION
 #=================================================
 
-cp -a ./php-fpm.conf /etc/php5/fpm/pool.d/$app.conf
+ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
+ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
## Problem
- *Backup and restore forget 20-$app.ini, if you try an upgrade after that, it would fail because this file is missing.*

## Solution
- *Add the lines for this file in backup and restore*
- *And, by the way, update these scripts and fix https://github.com/YunoHost-Apps/wallabag2_ynh/issues/38*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wallabag2_ynh%20fix_restore%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wallabag2_ynh%20fix_restore%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.