### PR TITLE
Fix 413 request entity too large

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,6 +8,7 @@ location __PATH__/ {
   client_body_timeout 60m;
   proxy_read_timeout 60m;
   fastcgi_read_timeout 60m;
+  client_max_body_size 50M;
 
   try_files $uri @__NAME__;
 

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,1 +1,3 @@
 max_execution_time=3600
+upload_max_filesize = 50M
+post_max_size = 50M


### PR DESCRIPTION
This fix an issue when you try to import wallabag articles:

https://forum.yunohost.org/t/wallabag2-413-request-entity-too-large/5124https://forum.yunohost.org/t/wallabag2-413-request-entity-too-large/5124

## Problem
- *Description of why you made this PR*

## Solution
- *And how you fix that*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wallabag2_ynh%20fix-413-request-entity-too-large%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wallabag2_ynh%20fix-413-request-entity-too-large%20(Official)/) 

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.