### PR TITLE
Remove ini file for php

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -390,3 +390,7 @@ catch_workers_output = yes
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+php_admin_value[max_execution_time] = 3600
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[post_max_size] = 50M

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,3 +1,0 @@
-max_execution_time=3600
-upload_max_filesize = 50M
-post_max_size = 50M

--- a/scripts/backup
+++ b/scripts/backup
@@ -45,7 +45,6 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
-ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP MYSQL DB

--- a/scripts/restore
+++ b/scripts/restore
@@ -81,7 +81,6 @@ chown -R $app: $final_path
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
-ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
## Problem
- *Have a look to https://github.com/YunoHost-Apps/nextcloud_ynh/issues/138 for more information*

## Solution
- *Get rid of the ini file and merge its content into the pool file.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Josué
- [x] **Approval (LGTM)** : Josué
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wallabag2_ynh%20remove_php_ini%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wallabag2_ynh%20remove_php_ini%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
