### PR TITLE
Add Fail2ban support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ this package:
  * Integrate with YunoHost users and SSO - i.e. logout button
  * Allow one user to be the administrator (set at the installation)
  * Asynchronous import using Redis (need to be enabled in the *Internal Settings*). RabbitMQ import not supported (yet ?)
+ * Supports fail2ban - protects you from password brute force attacks.
 
 ## Known issue(s)
 - Removing a Yunohost's user won't delete the related wallabag user, but only desactivate it. You need to manualy remove it from wallabag before. See: https://github.com/YunoHost-Apps/wallabag2_ynh/issues/39

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 This is a Wallabag v2 package for YunoHost.
 
+![wallabag start screen](https://www.linuxbabe.com/wp-content/uploads/2016/10/wallabag-quick-start-page.png)
+
+
 ---
 
 **NB: Since @jeromelebleu is no longer maintaining this package, I (@lapineige) take over this repository. But I have limited time and experience, so feel free to help !**
@@ -45,7 +48,7 @@ For the migration process, please refer to the
  * YunoHost website: https://yunohost.org/
  * [Video demo](https://player.vimeo.com/video/167435064)
  
- 
+--- 
 ---
 Wallabag pour Yunohost - [Version Française]
 ---

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,6 +8,7 @@ location __PATH__/ {
   client_body_timeout 60m;
   proxy_read_timeout 60m;
   fastcgi_read_timeout 60m;
+  client_max_body_size 50M;
 
   try_files $uri @__NAME__;
 

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -390,3 +390,7 @@ catch_workers_output = yes
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+php_admin_value[max_execution_time] = 3600
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[post_max_size] = 50M

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,1 +1,0 @@
-max_execution_time=3600

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     },
     "multi_instance": true,
     "requirements": {
-        "yunohost": ">= 2.7.12"
+        "yunohost": ">= 3.5.0"
     },
     "services": [
         "nginx",

--- a/scripts/backup
+++ b/scripts/backup
@@ -52,3 +52,10 @@ ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
 
 ynh_mysql_dump_db "$db_name" > db.sql
 CHECK_SIZE "db.sql"
+
+#=================================================
+# BACKUP FAIL2BAN CONFIGURATION
+#=================================================
+
+ynh_backup "/etc/fail2ban/jail.d/$app.conf"
+ynh_backup "/etc/fail2ban/filter.d/$app.conf"

--- a/scripts/backup
+++ b/scripts/backup
@@ -45,7 +45,6 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
-ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP MYSQL DB

--- a/scripts/install
+++ b/scripts/install
@@ -139,7 +139,7 @@ mkdir -p "/var/www/$app/var/logs/"
 touch "/var/www/$app/var/logs/prod.log"
 chown $app: "/var/www/$app/var/logs/prod.log"
 # Add fail2ban config
-ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "[\w]", from IP "<HOST>"' --max_retry=5
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "([\w]+)?", from IP "<HOST>"' --max_retry=5
 
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -139,7 +139,7 @@ mkdir -p "/var/www/$app/var/logs/"
 touch "/var/www/$app/var/logs/prod.log"
 chown $app: "/var/www/$app/var/logs/prod.log"
 # Add fail2ban config
-ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex="app.ERROR: Authentication failure" --max_retry=5
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "[\w]", from IP "<host>"' --max_retry=5
 
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -130,6 +130,11 @@ exec_console $app "$final_path" fos:user:promote --super "$admin"
 # Configure Wallabag instance URL
 ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_setting SET value = 'https://$domain$path_url' WHERE name = 'wallabag_url'"
 
+# Configure Fail2Ban
+
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex="app.ERROR: Authentication failure" --max_retry=5
+
+
 #=================================================
 # NGINX CONFIGURATION
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -139,7 +139,7 @@ mkdir -p "/var/www/$app/var/logs/"
 touch "/var/www/$app/var/logs/prod.log"
 chown $app: "/var/www/$app/var/logs/prod.log"
 # Add fail2ban config
-ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "[\w]", from IP "<host>"' --max_retry=5
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "[\w]", from IP "<HOST>"' --max_retry=5
 
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -130,7 +130,9 @@ exec_console $app "$final_path" fos:user:promote --super "$admin"
 # Configure Wallabag instance URL
 ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_setting SET value = 'https://$domain$path_url' WHERE name = 'wallabag_url'"
 
-# Configure Fail2Ban
+#=================================================
+# CONFIGURE FAIL2BAN
+#=================================================
 
 ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex="app.ERROR: Authentication failure" --max_retry=5
 

--- a/scripts/install
+++ b/scripts/install
@@ -134,6 +134,11 @@ ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_s
 # CONFIGURE FAIL2BAN
 #=================================================
 
+# Create the log file is not already existing during install
+mkdir -p "/var/www/$app/var/logs/"
+touch "/var/www/$app/var/logs/prod.log"
+chown $app: "/var/www/$app/var/logs/prod.log"
+# Add fail2ban config
 ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex="app.ERROR: Authentication failure" --max_retry=5
 
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -55,6 +55,22 @@ ynh_remove_nginx_config
 systemctl restart php5-fpm
 systemctl reload nginx
 
+
+#=================================================
+# REMOVE FAIL2BAN CONFIGURATION
+#=================================================
+
+ynh_remove_fail2ban_config
+
+#=================================================
+
+# REMOVE DEDICATED USER
+
+#=================================================
+
+
+
+
 #=================================================
 # REMOVE DEDICATED USER
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -55,21 +55,11 @@ ynh_remove_nginx_config
 systemctl restart php5-fpm
 systemctl reload nginx
 
-
 #=================================================
 # REMOVE FAIL2BAN CONFIGURATION
 #=================================================
 
 ynh_remove_fail2ban_config
-
-#=================================================
-
-# REMOVE DEDICATED USER
-
-#=================================================
-
-
-
 
 #=================================================
 # REMOVE DEDICATED USER

--- a/scripts/restore
+++ b/scripts/restore
@@ -82,7 +82,7 @@ chown -R $app: $final_path
 ynh_restore_file "/etc/fail2ban/jail.d/$app.conf"
 ynh_restore_file "/etc/fail2ban/filter.d/$app.conf"
 
-ynh_systemd_action -a reload -n fail2ban # Reload instead of restart for better performance
+ynh_systemd_action --action=reload --service_name=fail2ban # Reload instead of restart for better performance
 
 #=================================================
 # RESTORE PHP-FPM CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -81,7 +81,6 @@ chown -R $app: $final_path
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
-ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -77,6 +77,14 @@ ynh_system_user_create $app	# Recreate the dedicated user, if not existing
 chown -R $app: $final_path
 
 #=================================================
+# RESTORE FAIL2BAN CONFIGURATION
+#=================================================
+ynh_restore_file "/etc/fail2ban/jail.d/$app.conf"
+ynh_restore_file "/etc/fail2ban/filter.d/$app.conf"
+
+systemctl reload fail2ban # Reload instead of restart for better performance
+
+#=================================================
 # RESTORE PHP-FPM CONFIGURATION
 #=================================================
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -82,7 +82,7 @@ chown -R $app: $final_path
 ynh_restore_file "/etc/fail2ban/jail.d/$app.conf"
 ynh_restore_file "/etc/fail2ban/filter.d/$app.conf"
 
-systemctl reload fail2ban # Reload instead of restart for better performance
+ynh_systemd_action -a reload -n fail2ban # Reload instead of restart for better performance
 
 #=================================================
 # RESTORE PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -113,6 +113,9 @@ exec_console $app "${final_path}" cache:clear
 # Configure Wallabag instance URL
 ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_setting SET value = 'https://$domain$path_url' WHERE name = 'wallabag_url'"
 
+# Set-up fail2ban
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex="app.ERROR: Authentication failure" --max_retry=5 # same as install config
+
 #=================================================
 # NGINX CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,7 +114,7 @@ exec_console $app "${final_path}" cache:clear
 ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_setting SET value = 'https://$domain$path_url' WHERE name = 'wallabag_url'"
 
 # Set-up fail2ban
-ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex="app.ERROR: Authentication failure" --max_retry=5 # same as install config
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "[\w]", from IP "<HOST>"' --max_retry=5 # same as install config
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,6 +114,14 @@ exec_console $app "${final_path}" cache:clear
 ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_setting SET value = 'https://$domain$path_url' WHERE name = 'wallabag_url'"
 
 # Set-up fail2ban
+# Create the log file is not already existing
+if [ ! -f "/var/www/$app/var/logs/prod.log" ];
+then
+mkdir -p "/var/www/$app/var/logs/"
+touch "/var/www/$app/var/logs/prod.log"
+chown $app: "/var/www/$app/var/logs/prod.log"
+fi
+# Add fail2ban config
 ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "([\w]+)?", from IP "<HOST>"' --max_retry=5 # same as install config
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,7 +114,7 @@ exec_console $app "${final_path}" cache:clear
 ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_setting SET value = 'https://$domain$path_url' WHERE name = 'wallabag_url'"
 
 # Set-up fail2ban
-ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "[\w]", from IP "<HOST>"' --max_retry=5 # same as install config
+ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "([\w]+)?", from IP "<HOST>"' --max_retry=5 # same as install config
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -115,14 +115,14 @@ ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_user"  <<< "UPDATE craue_config_s
 
 # Set-up fail2ban
 # Create the log file is not already existing
-if [ ! -f "/var/www/$app/var/logs/prod.log" ];
+if [ ! -f "$final_path/var/logs/prod.log" ]
 then
-mkdir -p "/var/www/$app/var/logs/"
-touch "/var/www/$app/var/logs/prod.log"
-chown $app: "/var/www/$app/var/logs/prod.log"
+  mkdir -p "$final_path/var/logs/"
+  touch "$final_path/var/logs/prod.log"
+  chown $app: "$final_path/var/logs/prod.log"
 fi
 # Add fail2ban config
-ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "([\w]+)?", from IP "<HOST>"' --max_retry=5 # same as install config
+ynh_add_fail2ban_config --logpath="$final_path/var/logs/prod.log" --failregex='app.ERROR: Authentication failure for user "([\w]+)?", from IP "<HOST>"' --max_retry=5 # same as install config
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
## Problem
- Wallabag is not protected by fail2ban against brute force
See #37 

## Solution
- Add fail2ban config.

The number of retry is set to 5, I think it allows users to make a reasonable number of errors while restricting brute force possibilities.

**Warning** : this PR will drop support for version older than 3.5, in particular Yunohost 2.7 (Debian 8).

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wallabag2_ynh%20PR65/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wallabag2_ynh%20PR65/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
