### PR TITLE
Update to 2.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It extracts content so that you can read it when you have time.
 
 It provides a web interface, browser (Firefox / Chrome / Opera) add-ons, mobile apps (Android / iOS / Windows Phone) and even on e-reader (PocketBook / Kobo).
 
-**Shipped version:** 2.3.2
+**Shipped version:** 2.3.8
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -14,7 +14,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Sont disponibles: une interface web, des add-ons pour navigateurs (Firefox / Chrome / Opera), des applications pour mobile (Android / iOS / Windows Phone) et même sur liseuse (PocketBook / Kobo).
 
-**Version incluse:** 2.3.2
+**Version incluse:** 2.3.8
 
 ## Captures d'écran
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.3.7.tar.gz
-SOURCE_SUM=e223de12d8ea9f889e8660df4555c37c965f5ae1ca77af3d3532ab76889762cf
+SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.3.8.tar.gz
+SOURCE_SUM=58f319ee41828fcc4fd00a14c4ac7c16b2179a47af21e257a15938311d1426eb
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.3.8-1~ynh2",
+    "version": "2.3.8-1~ynh1",
     "url": "https://www.wallabag.org",
     "license": "MIT",
     "maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.3.8-1~ynh1",
+    "version": "2.3.8~ynh1",
     "url": "https://www.wallabag.org",
     "license": "MIT",
     "maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.3.7-1~ynh2",
+    "version": "2.3.8-1~ynh2",
     "url": "https://www.wallabag.org",
     "license": "MIT",
     "maintainer": {


### PR DESCRIPTION
## Problem
- Wallabag is not up-to-date.

## Solution
- Update the source

Minor release, mainly bug fixing: https://github.com/wallabag/wallabag/releases/tag/2.3.8
Last one before 2.4 (which is likely to require more work).

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wallabag2_ynh%20PR71/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wallabag2_ynh%20PR71/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.