### PR TITLE
fix wrong user in hooks

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-app="wallabag2"
-user="wallabag2"
+app="__APP__"
+user="__APP__"
 
 # Retrieve arguments
 username=$1

--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 app="wallabag2"
+user="wallabag2"
 
 # Retrieve arguments
 username=$1
@@ -14,5 +15,5 @@ user_pass=$(ynh_string_random)
 
 # Create the new user in Wallabag
 (cd "/var/www/$app" && \
- sudo sudo -u "www-data" php "bin/console" --no-interaction --env=prod \
+ sudo -u "$user" php "bin/console" --no-interaction --env=prod \
     fos:user:create "$username" "$user_email" "$user_pass")

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-app="wallabag2"
-user="wallabag2"
+app="__APP__"
+user="__APP__"
 
 # Retrieve arguments
 username=$1

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 app="wallabag2"
+user="wallabag2"
 
 # Retrieve arguments
 username=$1
@@ -8,5 +9,5 @@ purge=$2
 
 # Deactivate the user from Wallabg
 (cd "/var/www/$app" && \
- sudo sudo -u "www-data" php "bin/console" --no-interaction --env=prod \
+ sudo -u "$user" php "bin/console" --no-interaction --env=prod \
     fos:user:deactivate "$username")

--- a/scripts/install
+++ b/scripts/install
@@ -168,6 +168,13 @@ chown -R $app: $final_path
 chmod 755 $final_path
 
 #=================================================
+# SETUP HOOKS
+#=================================================
+
+ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="../hooks/post_user_create"
+ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="../hooks/post_user_delete"
+
+#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Configuring SSOwat..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -188,6 +188,13 @@ chown -R $app: $final_path
 chmod 755 $final_path
 
 #=================================================
+# SETUP HOOKS
+#=================================================
+
+ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="../hooks/post_user_create"
+ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="../hooks/post_user_delete"
+
+#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Upgrading SSOwat configuration..."


### PR DESCRIPTION
## Problem
- *Adding or deleting yunohost user raises a permission denied error on wallabag post_user_create or post_user_delete hooks*

## Solution
- *Use correct user in script command*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wallabag2_ynh%20PR74/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wallabag2_ynh%20PR74/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
