### PR TITLE
Reduces access permissions to db password

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -160,12 +160,13 @@ ynh_add_fail2ban_config --logpath="/var/www/$app/var/logs/prod.log" --failregex=
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-# Restrict rights to Wallabag user only
-chmod 600 $wb_conf
-
 # Set permissions to app files
 chown -R $app: $final_path
 chmod 755 $final_path
+
+# Restrict rights to Wallabag user only
+chmod 600 $wb_conf # parameter file should not be accessible by any other user
+chmod 700 $final_path/var/cache/prod/appProdProjectContainer.php # contains database password, should not be readable by another user
 
 #=================================================
 # SETUP HOOKS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -191,12 +191,13 @@ fi
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-# Restrict rights to Wallabag user only
-chmod 600 $wb_conf
-
 # Set permissions to app files
 chown -R $app: $final_path
 chmod 755 $final_path
+
+# Restrict rights to Wallabag user only
+chmod 600 $wb_conf # parameter file should not be accessible by any other user
+chmod 700 $final_path/var/cache/prod/appProdProjectContainer.php # contains database password, should not be readable by another user
 
 #=================================================
 # SETUP HOOKS


### PR DESCRIPTION
## Problem
- Database password is stored in a (too)widely readable file : any user can read it.
- Fix #94

## Solution
- Restrict permissions to Wallabag user only

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.
