### PR TITLE
Specify PHP version in every calls

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,7 +7,7 @@
 phpversion="7.4"
 
 # dependencies used by the app
-pkg_dependencies="php$phpversion-cli php$phpversion-mysql php$phpversion-json php$phpversion-gd php$phpversion-tidy php$phpversion-curl php-gettext php$phpversion-redis"
+pkg_dependencies="php$phpversion-cli php$phpversion-mysql php$phpversion-json php$phpversion-gd php$phpversion-tidy php$phpversion-curl php-gettext php$phpversion-redis php$phpversion-xml"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-phpversion="7.3"
+phpversion="7.4"
 
 # dependencies used by the app
 pkg_dependencies="php$phpversion-cli php$phpversion-mysql php$phpversion-json php$phpversion-gd php$phpversion-tidy php$phpversion-curl php-gettext php$phpversion-redis"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,8 +4,10 @@
 # COMMON VARIABLES
 #=================================================
 
+phpversion="7.3"
+
 # dependencies used by the app
-pkg_dependencies="php$YNH_DEFAULT_PHP_VERSION-cli php$YNH_DEFAULT_PHP_VERSION-mysql php$YNH_DEFAULT_PHP_VERSION-json php$YNH_DEFAULT_PHP_VERSION-gd php$YNH_DEFAULT_PHP_VERSION-tidy php$YNH_DEFAULT_PHP_VERSION-curl php$YNH_DEFAULT_PHP_VERSION-php-gettext php$YNH_DEFAULT_PHP_VERSION-redis"
+pkg_dependencies="php$phpversion-cli php$phpversion-mysql php$phpversion-json php$phpversion-gd php$phpversion-tidy php$phpversion-curl php-gettext php$phpversion-redis"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -96,7 +96,7 @@ ynh_add_nginx_config
 ynh_script_progression --message="Configuring PHP-FPM..." --weight=2
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config
+ynh_add_fpm_config --phpversion=$phpversion
 
 #=================================================
 # SPECIFIC SETUP
@@ -121,7 +121,7 @@ ynh_replace_string --match_string="secret: ovmpmAWXRCabNlMgzlzFXDYmCFfzGv" --rep
 ynh_replace_string --match_string="domain_name: https://your-wallabag-url-instance.com" --replace_string="domain_name: https://$domain$path_url" --target_file=$wb_conf
 
 # Alias for php-cli execution command
-php_exec="ynh_exec_as $app php "$final_path/bin/console" --no-interaction --env=prod"
+php_exec="ynh_exec_as $app php$phpversion "$final_path/bin/console" --no-interaction --env=prod"
 
 # Set permissions to app files
 chown -R $app: $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -123,7 +123,7 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Upgrading PHP-FPM configuration..."
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config
+ynh_add_fpm_config --phpversion=$phpversion
 
 # Set-up fail2ban
 # Create the log file is not already existing
@@ -164,7 +164,7 @@ then
 	#=================================================
 
 	# Alias for php-cli execution command
-	php_exec="ynh_exec_as $app php "$final_path/bin/console" --no-interaction --env=prod"
+	php_exec="ynh_exec_as $app php$phpversion "$final_path/bin/console" --no-interaction --env=prod"
 
 	# Set permissions to app files
 	chown -R $app: $final_path


### PR DESCRIPTION
We should set the PHP version instead of being exposed to bug if `YNH_DEFAULT_PHP_VERSION` changes.
Moreover, the [documentation](https://doc.wallabag.org/en/admin/installation/requirements.html#requirements) says they are not sure if PHP 7.4 is compatible.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
