### PR TITLE
Upgrade to 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It extracts content so that you can read it when you have time.
 It provides a web interface, browser (Firefox / Chrome / Opera) add-ons, mobile apps (Android / iOS / Windows Phone) and even on e-reader (PocketBook / Kobo).
 
 
-**Shipped version:** 2.4.3~ynh1
+**Shipped version:** 2.5.0~ynh1
 
 **Demo:** https://demo.yunohost.org/wallabag/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Sont disponibles une interface web, des add-ons pour navigateurs (Firefox / Chrome / Opera), des applications pour mobile (Android / iOS / Windows Phone) et même sur liseuse (PocketBook / Kobo).
 
 
-**Version incluse :** 2.4.3~ynh1
+**Version incluse :** 2.5.0~ynh1
 
 **Démo :** https://demo.yunohost.org/wallabag/
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.4.3.tar.gz
-SOURCE_SUM=bba4df940cf1a1ac632e134cbf9b9af8d3c1bf89311b2720cf64179e1b431d3a
+SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.5.0.tar.gz
+SOURCE_SUM=7c4ff86d5c08990d37c2b7ddaf1e8096e94edb15353361c8692386a5301bd361
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.4.3~ynh1",
+    "version": "2.5.0~ynh1",
     "url": "https://www.wallabag.org",
     "upstream": {
         "license": "MIT",


### PR DESCRIPTION
Wallabag 2.5 has been released https://wallabag.org/en/news/new-release-wallabag-2-5-0

:warning: PHP 7.4 is the minimum version required now, php 8.0 will be the minimum for the next major version (2.6).
#128 should already switch to php7.4.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
