### PR TITLE
Fix/debian11

### DIFF
--- a/check_process
+++ b/check_process
@@ -15,6 +15,8 @@
 		upgrade=1	from_commit=f75d58cb32c51a0981333ea88974dc3199324e65
 		# 2.3.8~ynh3
 		upgrade=1	from_commit=2e20b8f9a6b791e059b806fcfc2253f88d1aeaf2
+		# 2.3.8~ynh4
+		upgrade=1	from_commit=4da53256350d7e4d63812ed3244e945346a5d9b7
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.3.8~ynh4",
+    "version": "2.3.8~ynh5",
     "url": "https://www.wallabag.org",
     "upstream": {
         "license": "MIT",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,6 +4,10 @@
 # COMMON VARIABLES
 #=================================================
 
+# Overload "default php" version to bypass package limitation not ready to use 7.4 yet (version 2.4.0 minimun. See https://github.com/wallabag/wallabag/blob/master/CHANGELOG.md#240)
+# Fallback to php 7.3 as on debian 11 / bulleyes, 7.4 is used by default
+YNH_DEFAULT_PHP_VERSION=7.3
+
 # dependencies used by the app
 pkg_dependencies="php$YNH_DEFAULT_PHP_VERSION-cli php$YNH_DEFAULT_PHP_VERSION-mysql php$YNH_DEFAULT_PHP_VERSION-json php$YNH_DEFAULT_PHP_VERSION-gd php$YNH_DEFAULT_PHP_VERSION-tidy php$YNH_DEFAULT_PHP_VERSION-curl php$YNH_DEFAULT_PHP_VERSION-php-gettext php$YNH_DEFAULT_PHP_VERSION-redis"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -16,8 +16,9 @@ php$YNH_DEFAULT_PHP_VERSION-json
 php$YNH_DEFAULT_PHP_VERSION-gd
 php$YNH_DEFAULT_PHP_VERSION-tidy
 php$YNH_DEFAULT_PHP_VERSION-curl
-php$YNH_DEFAULT_PHP_VERSION-php-gettext
+php$YNH_DEFAULT_PHP_VERSION-gettext
 php$YNH_DEFAULT_PHP_VERSION-redis
+php$YNH_DEFAULT_PHP_VERSION-common
 "
 
 #=================================================

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,16 @@
 YNH_DEFAULT_PHP_VERSION=7.3
 
 # dependencies used by the app
-pkg_dependencies="php$YNH_DEFAULT_PHP_VERSION-cli php$YNH_DEFAULT_PHP_VERSION-mysql php$YNH_DEFAULT_PHP_VERSION-json php$YNH_DEFAULT_PHP_VERSION-gd php$YNH_DEFAULT_PHP_VERSION-tidy php$YNH_DEFAULT_PHP_VERSION-curl php$YNH_DEFAULT_PHP_VERSION-php-gettext php$YNH_DEFAULT_PHP_VERSION-redis"
+pkg_dependencies="
+php$YNH_DEFAULT_PHP_VERSION-cli
+php$YNH_DEFAULT_PHP_VERSION-mysql
+php$YNH_DEFAULT_PHP_VERSION-json
+php$YNH_DEFAULT_PHP_VERSION-gd
+php$YNH_DEFAULT_PHP_VERSION-tidy
+php$YNH_DEFAULT_PHP_VERSION-curl
+php$YNH_DEFAULT_PHP_VERSION-php-gettext
+php$YNH_DEFAULT_PHP_VERSION-redis
+"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,20 +6,27 @@
 
 # Overload "default php" version to bypass package limitation not ready to use 7.4 yet (version 2.4.0 minimun. See https://github.com/wallabag/wallabag/blob/master/CHANGELOG.md#240)
 # Fallback to php 7.3 as on debian 11 / bulleyes, 7.4 is used by default
-YNH_DEFAULT_PHP_VERSION=7.3
+YNH_PHP_VERSION=7.3
 
 # dependencies used by the app
 pkg_dependencies="
-php$YNH_DEFAULT_PHP_VERSION-cli
-php$YNH_DEFAULT_PHP_VERSION-mysql
-php$YNH_DEFAULT_PHP_VERSION-json
-php$YNH_DEFAULT_PHP_VERSION-gd
-php$YNH_DEFAULT_PHP_VERSION-tidy
-php$YNH_DEFAULT_PHP_VERSION-curl
-php$YNH_DEFAULT_PHP_VERSION-gettext
-php$YNH_DEFAULT_PHP_VERSION-redis
-php$YNH_DEFAULT_PHP_VERSION-common
+php$YNH_PHP_VERSION-cli
+php$YNH_PHP_VERSION-mysql
+php$YNH_PHP_VERSION-json
+php$YNH_PHP_VERSION-gd
+php$YNH_PHP_VERSION-tidy
+php$YNH_PHP_VERSION-curl
+php$YNH_PHP_VERSION-gettext
+php$YNH_PHP_VERSION-redis
+php$YNH_PHP_VERSION-common
 "
+
+### sources for php version overload:
+# https://github.com/YunoHost-Apps/wallabag2_ynh/pull/128#pullrequestreview-986708050=
+# https://github.com/YunoHost-Apps/grav_ynh/blob/testing/scripts/_common.sh
+# https://github.com/YunoHost/example_ynh/blob/master/scripts/_common.sh
+# https://github.com/YunoHost/yunohost/blob/dev/helpers/php#L3-L6=
+###
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem

- App broken on Debian 11 because wallabag version "not yet" compatible with PHP 7.4 (default on yunohost with debian 11)
- fix https://github.com/YunoHost-Apps/wallabag2_ynh/issues/127

## Solution

- fallback to php 7.3

I'm not sure about the best way to deal with this. Here is my attempt.
CI seems happy but not sure if it was runned on debian bulleyes or buster

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
