### PR TITLE
Specify PHP version for Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It provides a web interface, browser (Firefox / Chrome / Opera) add-ons, mobile 
 
 **Shipped version:** 2.5.1~ynh2
 
+
 **Demo:** https://demo.yunohost.org/wallabag/
 
 ## Screenshots

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,8 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Sont disponibles une interface web, des add-ons pour navigateurs (Firefox / Chrome / Opera), des applications pour mobile (Android / iOS / Windows Phone) et même sur liseuse (PocketBook / Kobo).
 
 
-**Version incluse :** 2.5.1~ynh2
+**Version incluse :** 2.5.1~ynh2
+
 
 **Démo :** https://demo.yunohost.org/wallabag/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Sont disponibles une interface web, des add-ons pour navigateurs (Firefox / Chrome / Opera), des applications pour mobile (Android / iOS / Windows Phone) et même sur liseuse (PocketBook / Kobo).
 
 
-**Version incluse :** 2.5.1~ynh2
+**Version incluse :** 2.5.1~ynh3
 
 
 **Démo :** https://demo.yunohost.org/wallabag/

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
         "name": "lapineige"
     },
     "requirements": {
-        "yunohost": ">= 4.3.0"
+        "yunohost": ">= 11.0"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,7 +7,7 @@
 YNH_PHP_VERSION="7.4"
 
 # dependencies used by the app
-pkg_dependencies="php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-tidy php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-gettext php-redis php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-ldap php${YNH_PHP_VERSION}-intl"
+pkg_dependencies="php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-tidy php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-gettext php${YNH_PHP_VERSION}-redis php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-ldap php${YNH_PHP_VERSION}-intl"
 
 
 #=================================================


### PR DESCRIPTION
Would help alleviate situations like this : [forum.yunohost.org/t/nextcloud-does-not-install/21383](https://forum.yunohost.org/t/nextcloud-does-not-install/21383) and log [paste.yunohost.org/raw/ojojixukag](https://paste.yunohost.org/raw/ojojixukag)

⚠️ Bumps YunoHost requirement to 11

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
