### PR TITLE
2.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Wallabag for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/wallabag2.svg)](https://dash.yunohost.org/appci/app/wallabag2) ![Working status](https://ci-apps.yunohost.org/ci/badges/wallabag2.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/wallabag2.maintain.svg)  
+[![Integration level](https://dash.yunohost.org/integration/wallabag2.svg)](https://dash.yunohost.org/appci/app/wallabag2) ![Working status](https://ci-apps.yunohost.org/ci/badges/wallabag2.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/wallabag2.maintain.svg)
 [![Install Wallabag with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=wallabag2)
 
 *[Lire ce readme en français.](./README_fr.md)*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It extracts content so that you can read it when you have time.
 It provides a web interface, browser (Firefox / Chrome / Opera) add-ons, mobile apps (Android / iOS / Windows Phone) and even on e-reader (PocketBook / Kobo).
 
 
-**Shipped version:** 2.5.2~ynh1
+**Shipped version:** 2.5.3~ynh1
 
 **Demo:** https://demo.yunohost.org/wallabag/
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It extracts content so that you can read it when you have time.
 It provides a web interface, browser (Firefox / Chrome / Opera) add-ons, mobile apps (Android / iOS / Windows Phone) and even on e-reader (PocketBook / Kobo).
 
 
-**Shipped version:** 2.5.3~ynh1
+**Shipped version:** 2.5.4~ynh1
 
 **Demo:** https://demo.yunohost.org/wallabag/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,15 +5,15 @@ It shall NOT be edited by hand.
 
 # Wallabag pour YunoHost
 
-[![Niveau d'intégration](https://dash.yunohost.org/integration/wallabag2.svg)](https://dash.yunohost.org/appci/app/wallabag2) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/wallabag2.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/wallabag2.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/wallabag2.svg)](https://dash.yunohost.org/appci/app/wallabag2) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/wallabag2.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/wallabag2.maintain.svg)
 [![Installer Wallabag avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=wallabag2)
 
 *[Read this readme in english.](./README.md)*
 
-> *Ce package vous permet d'installer Wallabag rapidement et simplement sur un serveur YunoHost.
-Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l'installer et en profiter.*
+> *Ce package vous permet d’installer Wallabag rapidement et simplement sur un serveur YunoHost.
+Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l’installer et en profiter.*
 
-## Vue d'ensemble
+## Vue d’ensemble
 
 [Wallabag](https://www.wallabag.org/) est une application de lecture différée : elle  permet simplement d’archiver une page web en ne conservant que le contenu. Les éléments superflus (menus, publicités, etc.) sont supprimés.
 
@@ -24,9 +24,9 @@ Sont disponibles une interface web, des add-ons pour navigateurs (Firefox / Chro
 
 **Démo :** https://demo.yunohost.org/wallabag/
 
-## Captures d'écran
+## Captures d’écran
 
-![Capture d'écran de Wallabag](./doc/screenshots/screenshot1.webp)
+![Capture d’écran de Wallabag](./doc/screenshots/screenshot1.webp)
 
 ## Avertissements / informations importantes
 
@@ -55,9 +55,9 @@ Attention : Une mise à jour classique avec l'interface d'administration ou avec
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <https://www.wallabag.org>
-* Documentation officielle de l'admin : <https://doc.wallabag.org/en/>
-* Dépôt de code officiel de l'app : <https://github.com/wallabag/wallabag>
+* Site officiel de l’app : <https://www.wallabag.org>
+* Documentation officielle de l’admin : <https://doc.wallabag.org/en/>
+* Dépôt de code officiel de l’app : <https://github.com/wallabag/wallabag>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_wallabag2>
 * Signaler un bug : <https://github.com/YunoHost-Apps/wallabag2_ynh/issues>
 
@@ -73,4 +73,4 @@ ou
 sudo yunohost app upgrade wallabag2 -u https://github.com/YunoHost-Apps/wallabag2_ynh/tree/testing --debug
 ```
 
-**Plus d'infos sur le packaging d'applications :** <https://yunohost.org/packaging_apps>
+**Plus d’infos sur le packaging d’applications :** <https://yunohost.org/packaging_apps>

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Sont disponibles une interface web, des add-ons pour navigateurs (Firefox / Chrome / Opera), des applications pour mobile (Android / iOS / Windows Phone) et même sur liseuse (PocketBook / Kobo).
 
 
-**Version incluse :** 2.5.3~ynh1
+**Version incluse :** 2.5.4~ynh1
 
 **Démo :** https://demo.yunohost.org/wallabag/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Sont disponibles une interface web, des add-ons pour navigateurs (Firefox / Chrome / Opera), des applications pour mobile (Android / iOS / Windows Phone) et même sur liseuse (PocketBook / Kobo).
 
 
-**Version incluse :** 2.5.2~ynh1
+**Version incluse :** 2.5.3~ynh1
 
 **Démo :** https://demo.yunohost.org/wallabag/
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.5.2.tar.gz
-SOURCE_SUM=43df3d4a8ac63e6dca06e4211808a7614e871886bd46b86d44fbf01802d4ea39
+SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.5.3.tar.gz
+SOURCE_SUM=6b7d33f6b75771f736795b92844a1b8035961ebf537ccc2af56c1a59dac8dd05
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.5.3.tar.gz
-SOURCE_SUM=6b7d33f6b75771f736795b92844a1b8035961ebf537ccc2af56c1a59dac8dd05
+SOURCE_URL=https://static.wallabag.org/releases/wallabag-release-2.5.4.tar.gz
+SOURCE_SUM=c953105e3181f18bf592541a1c46c318c6663ad00d4687052676b02a7d74c618
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.5.3~ynh1",
+    "version": "2.5.4~ynh1",
     "url": "https://www.wallabag.org",
     "upstream": {
         "license": "MIT",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable"
     },
-    "version": "2.5.2~ynh1",
+    "version": "2.5.3~ynh1",
     "url": "https://www.wallabag.org",
     "upstream": {
         "license": "MIT",

--- a/sources/patches/app-02-oauth-workaround.patch
+++ b/sources/patches/app-02-oauth-workaround.patch
@@ -1,6 +1,6 @@
 --- a/vendor/friendsofsymfony/oauth-server-bundle/Storage/OAuthStorage.php      2016-02-22 13:57:55.000000000 +0000
 +++ b/vendor/friendsofsymfony/oauth-server-bundle/Storage/OAuthStorage.php      2017-04-13 17:16:06.298501506 +0000
-@@ -166,7 +166,7 @@
+@@ -170,7 +170,7 @@
          if (null !== $user) {
              $encoder = $this->encoderFactory->getEncoder($user);
 


### PR DESCRIPTION
- Wallabag 2.5.3 https://github.com/wallabag/wallabag/releases/tag/2.5.3 has been released.
It a security fix upgrade, but not an urgent one (no breach from outside or similar), so I will merge this as soon as the continuous integration result is ready.

- Then Wallabag 2.5.4, security release again : https://github.com/wallabag/wallabag/releases/tag/2.5.4

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
