### PR TITLE
fix: add time for php script to run a 'long sync' with an application

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -2,3 +2,4 @@
 
 php_admin_value[upload_max_filesize] = 50M
 php_admin_value[post_max_size] = 50M
+php_admin_value[max_execution_time] = 300


### PR DESCRIPTION
## Problem

- Syncing from the phone to the wallabag server failed. The sync was broken on the app and there was a lot of local data to push to the server
- In the php logs : ``PHP message: PHP Fatal error:  Maximum execution time of 30 seconds exceeded``

See https://github.com/wallabag/wallabag/issues/3950 and https://github.com/wallabag/android-app/issues/751

## Solution

- Give more time to PHP for the sync.
  - https://github.com/wallabag/docker/blob/master/root/etc/php81/php.ini#L385
  - https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time
- 300 sec was not enough for me so I had to put 3000 but it seems huge so I kept the "default value" from wallabag project

## PR Status

I edited the php config on the server, I did not test this PR.

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
