### PR TITLE
Fixes warning `ynh_exec_as_app: command not found` while creating/deleting user

### DIFF
--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Source YunoHost helpers
+YNH_HELPERS_VERSION=2.1
 source /usr/share/yunohost/helpers
 
 app="__APP__"

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Source YunoHost helpers
+YNH_HELPERS_VERSION=2.1
 source /usr/share/yunohost/helpers
 
 app="__APP__"


### PR DESCRIPTION
## Problem

Creating a user produces a warning for `./50-wallabag2: line 20: ynh_exec_as_app: command not found`.
<sup>Used most recent version of YNH and Wallabag App.</sup>

<details>
<summary>Log of the error</summary>

```
DEBUG - Executing command '['sh', '-c', '/bin/bash -x "./50-nextcloud" gambeta gambeta@maindomain.tld 7>&1']'
DEBUG - + user=gambeta
DEBUG - ++ basename ./50-nextcloud
DEBUG - ++ cut -d- -f 2-
DEBUG - + setfacl --recursive --modify g:nextcloud:rwX,d:g:nextcloud:rwX /home/gambeta
DEBUG - Executing command '['sh', '-c', '/bin/bash -x "./50-wallabag2" gambeta gambeta@maindomain.tld 7>&1']'
DEBUG - + source /usr/share/yunohost/helpers
DEBUG - ++++ dirname -- /usr/share/yunohost/helpers
DEBUG - +++ cd -- /usr/share/yunohost
DEBUG - +++ pwd
DEBUG - ++ SCRIPT_DIR=/usr/share/yunohost
DEBUG - ++ YNH_HELPERS_VERSION=1
DEBUG - ++ readonly 'XTRACE_ENABLE=set -o xtrace'
DEBUG - ++ XTRACE_ENABLE='set -o xtrace'
DEBUG - + user=wallabag2
DEBUG - ++ ynh_app_setting_get --app=wallabag2 --key=install_dir
DEBUG - + install_dir=/var/www/wallabag2
DEBUG - ++ ynh_app_setting_get --app=wallabag2 --key=php_version
DEBUG - + php_version=8.2
DEBUG - + username=gambeta
DEBUG - + user_email=gambeta@maindomain.tld
DEBUG - ++ ynh_string_random
DEBUG - ++ length=24
DEBUG - ++ filter=A-Za-z0-9
DEBUG - ++ dd if=/dev/urandom bs=1 count=1000
DEBUG - ++ tr --complement --delete A-Za-z0-9
DEBUG - ++ sed --quiet 's/\(.\{24\}\).*/\1/p'
DEBUG - + user_pass=**********
DEBUG - + pushd /var/www/wallabag2
2025-09-08 22:34:03,647: WARNING - ./50-wallabag2: line 20: ynh_exec_as_app: command not found
DEBUG - /var/www/wallabag2 /etc/yunohost/hooks.d/post_user_create
DEBUG - + ynh_exec_as_app php8.2 bin/console --no-interaction --env=prod fos:user:create gambeta gambeta@maindomain.tld **********
DEBUG - + popd
DEBUG - /etc/yunohost/hooks.d/post_user_create
SUCCESS - User created
```
</details>

## Solution

Specifying helper version as 2.1, rather than using the default 1, avoids the warning. Haven't put much into figuring out why though.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
